### PR TITLE
fix: remote transform for sliderByPaletteType and widen white selection

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -321,10 +321,7 @@ class _ColorPickerState extends State<ColorPicker> {
           SizedBox(
             height: 20.0,
             width: widget.colorPickerWidth,
-            child: Transform.flip(
-              flipX: true,
-              child: sliderByPaletteType(),
-            ),
+            child: sliderByPaletteType(),
           ),
           if (widget.enableAlpha)
             Padding(

--- a/lib/src/palette.dart
+++ b/lib/src/palette.dart
@@ -1456,8 +1456,10 @@ class HUEColorWheelPainter extends CustomPainter {
     const Gradient gradientR = RadialGradient(
       colors: [
         Colors.white,
+        // Colors.white,
         Color(0x00FFFFFF),
       ],
+      stops: [0.2, 1.0],
     );
 
     canvas.drawRect(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_colorpicker
 description: HSV(HSB)/HSL/RGB/Material color picker inspired by all the good design for your amazing flutter apps.
-version: 1.1.4
+version: 1.1.5
 homepage: https://github.com/mchome/flutter_colorpicker
 
 environment:


### PR DESCRIPTION
- [x] removed transform for sliderByPaletteType
- [x] widen white selection

![Screen Recording 2025-04-28 at 11 27 13](https://github.com/user-attachments/assets/e3a72c40-959d-443a-b805-93b74015cf9f)
